### PR TITLE
Epsilon Badges uses ENSL team ID for badge name

### DIFF
--- a/lua/shine/extensions/epsilonbadges.lua
+++ b/lua/shine/extensions/epsilonbadges.lua
@@ -121,9 +121,10 @@ function Plugin:OnReceiveENSLData( Client, Data )
 	if type(Data) ~= "table" then return end
 
 	local Teamname = Data.team and Data.team.name
+	local TeamID = Data.team and string.format("ENSL%s", Data.team.id)
 
 	if Teamname then
-		self:SetBadge( Client, Teamname, self.Config.ENSLTeamsRow, string.format("ENSL Team - %s", Teamname))
+		self:SetBadge( Client, TeamID, self.Config.ENSLTeamsRow, string.format("ENSL Team - %s", Teamname))
 	end
 end
 


### PR DESCRIPTION
Previously, Epsilon Badges looked for badge image files that match the
ENSL team name. This is prone to change at the whim of players who discover
the latest meme. This commit changes Epsilon Badges to look for badge
image files that match "ENSLX", where X is the ENSL team ID. The team
ID is unique and immutable.